### PR TITLE
Add wishes in PlanSidebar props

### DIFF
--- a/src/components/screens/Plan/PlanScreen.tsx
+++ b/src/components/screens/Plan/PlanScreen.tsx
@@ -242,6 +242,7 @@ export const PlanScreen = (props: PlanScreenProps) => {
 								sharedWith={plan?.sharedWith ?? []}
 								owner={plan?.owner ?? undefined}
 								currency={currency ?? undefined}
+								wishes={plan?.wishes ?? []}
 								onPlanSettingsChange={onPlanSettingsChange}
 							/>
 						}

--- a/src/components/screens/Plan/PlanSidebar.tsx
+++ b/src/components/screens/Plan/PlanSidebar.tsx
@@ -3,6 +3,7 @@ import {
 	AvatarGroup,
 	Button,
 	Center,
+	Divider,
 	Input,
 	InputGroup,
 	InputRightAddon,
@@ -13,11 +14,12 @@ import {
 	NumberInputStepper,
 	Select,
 	Stack,
+	Tag,
 	Text,
 	Tooltip,
 	useColorModeValue,
 } from '@chakra-ui/react';
-import type { Plan, User } from '@prisma/client';
+import type { Plan, User, Wish } from '@prisma/client';
 import { trpc } from '@utils/trpc';
 import { useSession } from 'next-auth/react';
 import type { ChangeEvent } from 'react';
@@ -29,6 +31,7 @@ type PlanSidebarProps = {
 	sharedWith: User[];
 	owner?: User;
 	currency?: string;
+	wishes: Wish[];
 	onPlanSettingsChange: (
 		amountToSave: number,
 		currentAmountSaved: number,
@@ -99,6 +102,10 @@ export const PlanSidebar = (props: PlanSidebarProps) => {
 			planId: props.plan?.id,
 			emails: emails,
 		});
+	}
+
+	const calcTotalCost = (): number => {
+		return props.wishes?.reduce((sum, wish) => sum + wish.price, 0)
 	}
 
 	return (
@@ -200,6 +207,33 @@ export const PlanSidebar = (props: PlanSidebarProps) => {
 							<option value="e14d">Every 14th day</option>
 						</Select>
 					</Tooltip>
+					<Divider />
+					<Text
+						align={'center'}
+						textTransform={'uppercase'}
+						color={categoryColor}
+						fontWeight={700}
+						fontSize={'sm'}
+						letterSpacing={1}
+					>
+						Total Cost
+					</Text>
+					<Tooltip
+						hasArrow
+						label="Sum of prices of all the wishes in a Plan"
+						placement="auto"
+					>
+						<Tag
+						>
+							<Text
+								align={'center'}
+								textTransform={'uppercase'}
+							>
+								{calcTotalCost()} {props.currency}
+							</Text>
+						</Tag>
+					</Tooltip>
+					<Divider />
 					{frequency !== 'som' && frequency !== 'eom' && (
 						<>
 							<Text

--- a/src/components/screens/Plan/PlanSidebar.tsx
+++ b/src/components/screens/Plan/PlanSidebar.tsx
@@ -105,8 +105,8 @@ export const PlanSidebar = (props: PlanSidebarProps) => {
 	}
 
 	const calcTotalCost = (): number => {
-		return props.wishes?.reduce((sum, wish) => sum + wish.price, 0)
-	}
+		return props.wishes?.reduce((sum, wish) => sum + wish.price, 0);
+	};
 
 	return (
 		<Stack
@@ -223,12 +223,8 @@ export const PlanSidebar = (props: PlanSidebarProps) => {
 						label="Sum of prices of all the wishes in a Plan"
 						placement="auto"
 					>
-						<Tag
-						>
-							<Text
-								align={'center'}
-								textTransform={'uppercase'}
-							>
+						<Tag>
+							<Text align={'center'} textTransform={'uppercase'}>
 								{calcTotalCost()} {props.currency}
 							</Text>
 						</Tag>


### PR DESCRIPTION
## Proposed Changes

- Add 'wishes' value in PlanSidebar props.
- Create a new section in the sidebar to display total cost.
- A function to calculate total cost using array.reduce() JavaScript method.
<img width="1680" alt="Screenshot 2023-02-25 at 1 51 14 AM" src="https://user-images.githubusercontent.com/34695022/221343431-9b2bdd4d-fed4-471f-933e-9f44f733d402.png">


Fixes #84 
