### PR TITLE
Fixing slow lnitial loading animation of wishes

### DIFF
--- a/src/components/screens/Plan/PlanWish.tsx
+++ b/src/components/screens/Plan/PlanWish.tsx
@@ -193,7 +193,8 @@ export function PlanWishComponent(props: SortableItemProps) {
 			animate="enter"
 			variants={variants}
 			transition={{
-				duration: 0.1 * props.wish.placement,
+				duration: 0.05,
+				delay: 0.05 * props.wish.placement,
 				type: 'easeInOut',
 			}}
 			style={{ position: 'relative' }}

--- a/src/components/screens/WishList/WishCard.tsx
+++ b/src/components/screens/WishList/WishCard.tsx
@@ -76,7 +76,8 @@ export const WishCard = ({
 			animate="enter"
 			variants={variants}
 			transition={{
-				duration: 0.1 * index,
+				duration: 0.05,
+				delay: 0.05 * index,
 				type: 'easeInOut',
 			}}
 			style={{ position: 'relative' }}


### PR DESCRIPTION
## Proposed Changes

- Fixes #63 
  - Loading animation of wishes in plan and wish list has been shortened and using delay instead of increasing the animation time.

<!-- The following tasks should not be deleted, you need to check them off when completed after PR is created -->
- [x] Squash commits (where applicable)
- [x] Link Pull Request to issue(s) (where applicable)
